### PR TITLE
Fix user cancel server 500

### DIFF
--- a/src/main/kotlin/io/curity/identityserver/plugin/signicat/config/SignicatAuthenticatorPluginConfig.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugin/signicat/config/SignicatAuthenticatorPluginConfig.kt
@@ -74,6 +74,8 @@ interface SignicatAuthenticatorPluginConfig : Configuration
     val authenticatorInformationProvider: AuthenticatorInformationProvider
     
     val serverTrustCryptoStore: Optional<ServerTrustCryptoStore>
+
+    val serviceHelper: AuthenticatorInformationProvider
 }
 
 enum class PredefinedEnvironment

--- a/src/main/kotlin/io/curity/identityserver/plugin/signicat/config/SignicatAuthenticatorPluginConfig.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugin/signicat/config/SignicatAuthenticatorPluginConfig.kt
@@ -74,8 +74,6 @@ interface SignicatAuthenticatorPluginConfig : Configuration
     val authenticatorInformationProvider: AuthenticatorInformationProvider
     
     val serverTrustCryptoStore: Optional<ServerTrustCryptoStore>
-
-    val serviceHelper: AuthenticatorInformationProvider
 }
 
 enum class PredefinedEnvironment

--- a/src/main/kotlin/io/curity/identityserver/plugin/signicat/signing/SigningClientFactory.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugin/signicat/signing/SigningClientFactory.kt
@@ -52,7 +52,7 @@ class SigningClientFactory
         private val JAXWS_PROPERTIES_REQUEST_TIMEOUT = "com.sun.xml.ws.request.timeout"
     
         fun create(environment: String, clientKeyCryptoStore: Optional<ClientKeyCryptoStore>,
-                   trustStore : Optional<ServerTrustCryptoStore>): DocumentEndPoint
+                   trustStore: Optional<ServerTrustCryptoStore>): DocumentEndPoint
         {
             val client = DocumentService()
             val port = client.documentServiceEndPointPort


### PR DESCRIPTION
Server 500 error in Signicat when a user would cancel the authentication process in Signicat. The fix redirects the user back to the authenticator-selector page.