### PR TITLE
use sslSocketFactory only when it is initialized

### DIFF
--- a/src/main/kotlin/io/curity/identityserver/plugin/signicat/signing/SigningClientFactory.kt
+++ b/src/main/kotlin/io/curity/identityserver/plugin/signicat/signing/SigningClientFactory.kt
@@ -86,13 +86,12 @@ class SigningClientFactory
 
             if (trustManagers != null || keyManagers != null) {
                 sslContext.init(keyManagers, trustManagers, null)
+                val sslSocketFactory = sslContext.socketFactory
+
+                bindingProvider.requestContext.put(JAXWS_PROPERTIES_SSL_SOCKET_FACTORY, sslSocketFactory)
+                bindingProvider.requestContext.put(JAXWS_PROPERTIES_SSL_SOCKET_FACTORY_INTERNAL, sslSocketFactory)
             }
 
-            val sslSocketFactory = sslContext.socketFactory
-
-            bindingProvider.requestContext.put(JAXWS_PROPERTIES_SSL_SOCKET_FACTORY, sslSocketFactory)
-            bindingProvider.requestContext.put(JAXWS_PROPERTIES_SSL_SOCKET_FACTORY_INTERNAL, sslSocketFactory)
-        
             bindingProvider.requestContext.put(JAXWS_PROPERTIES_CONNECT_TIMEOUT, CONNECT_TIMEOUT)
             bindingProvider.requestContext.put(JAXWS_PROPERTIES_CONNECT_TIMEOUT_INTERNAL, CONNECT_TIMEOUT)
             bindingProvider.requestContext.put(JAXWS_PROPERTIES_REQUEST_TIMEOUT, REQUEST_TIMEOUT)


### PR DESCRIPTION
When no trustManager and keyManager are set, the SSLContextImpl was not initilized and calling sslContext.socketFactory threw an exception.
This PR fixes this.